### PR TITLE
fix/Motor joints

### DIFF
--- a/config/joint_limits.yml
+++ b/config/joint_limits.yml
@@ -1,0 +1,11 @@
+joint_limits:
+  rodadireita_joint:
+    has_velocity_limits: true
+    max_velocity: 15.0
+    has_effort_limits: true
+    max_effort: 78e-3
+  rodaesquerda_joint:
+    has_velocity_limits: true
+    max_velocity: 15.0
+    has_effort_limits: true
+    max_effort: 78e-3

--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -28,6 +28,8 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
     <!-- Load configs to control robot motors -->
     <rosparam command="load" file="$(find modelo_carrinho)/config/motor_drive.yml" />
 
+    <rosparam command="load" file="$(find modelo_carrinho)/config/joint_limits.yml" />
+
     <node name="robot_controller" pkg="controller_manager" type="spawner" args="robot_left_controller robot_right_controller"/>
 
   </group>

--- a/urdf/modelo_carrinho.urdf
+++ b/urdf/modelo_carrinho.urdf
@@ -419,7 +419,6 @@
       link="rodaesquerda_link" />
     <axis
       xyz="0 1 0" />
-    <limit effort="78e-3" velocity="15.0"/>
   </joint>
   <link
     name="rodadireita_link">
@@ -473,7 +472,6 @@
       link="rodadireita_link" />
     <axis
       xyz="0 1 0" />
-    <limit effort="78e-3" velocity="15.0"/>
   </joint>
   <link
     name="line2_link">

--- a/urdf/modelo_carrinho.urdf
+++ b/urdf/modelo_carrinho.urdf
@@ -419,6 +419,7 @@
       link="rodaesquerda_link" />
     <axis
       xyz="0 1 0" />
+    <limit effort="78e-3" velocity="15.0"/>
   </joint>
   <link
     name="rodadireita_link">
@@ -471,7 +472,8 @@
     <child
       link="rodadireita_link" />
     <axis
-      xyz="0 -1 0" />
+      xyz="0 1 0" />
+    <limit effort="78e-3" velocity="15.0"/>
   </joint>
   <link
     name="line2_link">


### PR DESCRIPTION
O eixo do joint da roda direita estava invertido, e fazia o robô girar no próprio eixo em vez de ir para frente quando colocavamos velocidades angulares positivas.

Além disso, o @FelipeGdM pegou os valores máximos de torque e velocidade angular desse motorzinho que usamos no modelo e adicionou o limite no urdf também.

Uma coisa importante de lembrar é configurar essas coisas direitinho na hora de exportar os modelos de cada grupo, já que tem que ficar diretamente no urdf